### PR TITLE
add basic API routes

### DIFF
--- a/src/routes/api/officeHours/+server.ts
+++ b/src/routes/api/officeHours/+server.ts
@@ -1,0 +1,40 @@
+import { getAllOfficeHours, getSingleOfficeHour } from '$lib/firebase/db';
+
+export async function GET(params: any): Promise<Response> {
+    const searchParams = params.url.searchParams;
+    const id = searchParams.get('id');
+    
+    //user requested an ID, try to fetch a single ofifce hour
+    if (id) {
+        try {
+            const data = await getSingleOfficeHour(id);
+
+            if (!data) {
+                throw new Error;
+            }
+    
+            return new Response(JSON.stringify(data), {
+                headers: {
+                    contentType: "application/json"
+                }
+            });
+        }
+        catch {
+            return new Response(JSON.stringify({
+                "status": `No office hour with id: ${id}`
+            }), {
+                status: 400,
+                statusText: `No office hour with id: ${id}`
+            });
+        }
+    }
+
+    //user did not request ID, send them all office hours
+    const data = await getAllOfficeHours();
+
+    return new Response(JSON.stringify(data), {
+        headers: {
+            contentType: "application/json"
+        }
+    })
+}

--- a/src/routes/api/users/+server.ts
+++ b/src/routes/api/users/+server.ts
@@ -1,0 +1,35 @@
+import { getUserData } from '$lib/firebase/db';
+
+export async function GET(params: any): Promise<Response> {
+    const searchParams = params.url.searchParams;
+    const id = searchParams.get('id');
+
+    //no id given
+    if (!id) {
+        return new Response(JSON.stringify({
+            "status": `No id provided!`
+        }), {
+            status: 400,
+            statusText: `No id provided!`
+        });
+    }
+
+    const userData = await getUserData(id);
+
+    //check if the data is valid or not
+    if (!userData) {
+        return new Response(JSON.stringify({
+            "status": `No user with id: ${id}`
+        }), {
+            status: 400,
+            statusText: `No user with id: ${id}`
+        });
+    }
+    else {
+        return new Response(JSON.stringify(userData), {
+            headers: {
+                contentType: "application/json"
+            }
+        });
+    }
+}


### PR DESCRIPTION
made some basic API routes. Resolves #2 

### routes
\/api/users?id={id}
* Get data for the user with the given id
* If there is no user with the given _id_ or _id_ is null, return a **400**

\/api/officeHours?id={id}
* The default behavior of this endpoint is to return a list of all office hours
* If a given _id_ is passed in, the server will try to send data from that _id_
  * If _id_ does not correspond to an officeHour, a **400** will be returned